### PR TITLE
Add remote deployment workflow

### DIFF
--- a/.github/workflows/deploy-remotes.yml
+++ b/.github/workflows/deploy-remotes.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy Remotes
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all remotes
+        run: node scripts/buildAll.mjs
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Upload remotes to Azure Storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            for dir in $(ls dist); do
+              if [ "$dir" = "host" ]; then
+                continue
+              fi
+              remote_name=$(echo "$dir" | tr '[:upper:]' '[:lower:]')
+              az storage blob upload-batch --account-name uiremotes -s "dist/$dir" -d "$web/remotes/$remote_name" --overwrite
+            done
+


### PR DESCRIPTION
## Summary
- add workflow to build all remotes
- upload each build to an Azure Storage container at `$web/remotes/<remote>`

## Testing
- `npm run build:all`

------
https://chatgpt.com/codex/tasks/task_e_68437a923b74832c98139e617848eb11