### PR TITLE
Implement versioned remote builds

### DIFF
--- a/.github/workflows/deploy-remotes.yml
+++ b/.github/workflows/deploy-remotes.yml
@@ -39,6 +39,11 @@ jobs:
         if: env.REMOTE_NAMES != ''
         run: npm ci
 
+      - name: Bump remote versions
+        if: env.REMOTE_NAMES != ''
+        run: |
+          REMOTE_NAMES="$REMOTE_NAMES" node scripts/bumpRemoteVersions.mjs
+
       - name: Build changed remotes
         if: env.REMOTE_NAMES != ''
         run: |

--- a/.github/workflows/deploy-remotes.yml
+++ b/.github/workflows/deploy-remotes.yml
@@ -10,38 +10,61 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed remotes
+        id: detect
+        shell: bash
+        run: |
+          base="${{ github.event.before }}"
+          if [ -z "$base" ]; then
+            base=$(git rev-parse HEAD^)
+          fi
+          dirs=$(git diff --name-only "$base" "$GITHUB_SHA" -- remotes | awk -F/ '/^remotes\/[^\/]+\//{print $2}' | sort -u | xargs)
+          echo "REMOTE_NAMES=$dirs" >> $GITHUB_ENV
+
+      - name: Exit if no remote changes
+        if: env.REMOTE_NAMES == ''
+        run: echo 'No remote changes detected.'
 
       - name: Setup Node.js
+        if: env.REMOTE_NAMES != ''
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'npm'
 
       - name: Install dependencies
+        if: env.REMOTE_NAMES != ''
         run: npm ci
 
-      - name: Build all remotes
-        run: node scripts/buildAll.mjs
+      - name: Build changed remotes
+        if: env.REMOTE_NAMES != ''
+        run: |
+          REMOTE_NAMES="$REMOTE_NAMES" node scripts/buildAll.mjs
 
       - name: Azure Login
+        if: env.REMOTE_NAMES != ''
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Ensure $web container exists
+        if: env.REMOTE_NAMES != ''
         uses: azure/CLI@v1
         with:
           inlineScript: |
             az storage container create --account-name uiremotes -n '$web' --auth-mode login
 
       - name: Upload remotes to Azure Storage
+        if: env.REMOTE_NAMES != ''
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            for dir in $(ls dist); do
-              if [ "$dir" = "host" ]; then
-                continue
-              fi
-              remote_name=$(echo "$dir" | tr '[:upper:]' '[:lower:]')
-              az storage blob upload-batch --account-name uiremotes -s "dist/$dir" -d '$web' --destination-path "remotes/$remote_name" --overwrite --auth-mode login
+            for remote in $REMOTE_NAMES; do
+              lower=$(echo "$remote" | tr '[:upper:]' '[:lower:]')
+              version=$(node -p "require('./remotes/${lower}/package.json').version")
+              az storage blob upload-batch --account-name uiremotes -s "dist/${remote}/${version}" -d '$web' --destination-path "remotes/${lower}/${version}" --overwrite --auth-mode login
+              az storage blob upload-batch --account-name uiremotes -s "dist/${remote}/${version}" -d '$web' --destination-path "remotes/${lower}/latest" --overwrite --auth-mode login
             done

--- a/.github/workflows/deploy-remotes.yml
+++ b/.github/workflows/deploy-remotes.yml
@@ -69,7 +69,7 @@ jobs:
           inlineScript: |
             for remote in $REMOTE_NAMES; do
               lower=$(echo "$remote" | tr '[:upper:]' '[:lower:]')
-              version=$(node -p "require('./remotes/${lower}/package.json').version")
+              version=$(grep -oP '"version":\s*"\K[^" ]+' "remotes/${lower}/package.json")
               az storage blob upload-batch --account-name uiremotes -s "dist/${remote}/${version}" -d '$web' --destination-path "remotes/${lower}/${version}" --overwrite --auth-mode login
               az storage blob upload-batch --account-name uiremotes -s "dist/${remote}/${version}" -d '$web' --destination-path "remotes/${lower}/latest" --overwrite --auth-mode login
             done

--- a/host/public/resume.md
+++ b/host/public/resume.md
@@ -44,7 +44,7 @@ GPA: 3.435 | Dean’s Honor List: 7 quarters
 
 ## Certifications
 
-- **Microsoft Azure Fundamentals** — *In Progress*  
+- **Microsoft Azure Fundamentals** 
   Currently taking a certification course focused on core Azure services, cloud concepts, and solutions.
 
 ---

--- a/host/src/App.js
+++ b/host/src/App.js
@@ -113,7 +113,7 @@ export default function App() {
 
     // Determine remote entry URL depending on environment
     const localUrl = `http://localhost:${port}/remoteEntry.js`;
-    const prodPath = `${remoteName.toLowerCase()}/remoteEntry.js`;
+    const prodPath = `${remoteName.toLowerCase()}/latest/remoteEntry.js`;
     const remoteEntryUrl = isDev
       ? localUrl
       : withRemotesPath(prodPath);

--- a/host/src/AppRoutes.js
+++ b/host/src/AppRoutes.js
@@ -57,7 +57,7 @@ const RemoteRoute = ({ remote, remotesList }) => {
 
           const remoteUrl = isDev
             ? `http://localhost:${port}/remoteEntry.js`
-            : withRemotesPath(`/${remoteConfig.name.toLowerCase()}/remoteEntry.js`);
+            : withRemotesPath(`/${remoteConfig.name.toLowerCase()}/latest/remoteEntry.js`);
 
           await loadRemoteEntry(remote.title, remoteUrl);
           await __webpack_init_sharing__("default");

--- a/host/src/AppRoutes.js
+++ b/host/src/AppRoutes.js
@@ -57,7 +57,7 @@ const RemoteRoute = ({ remote, remotesList }) => {
 
           const remoteUrl = isDev
             ? `http://localhost:${port}/remoteEntry.js`
-            : withRemotesPath(`/${remoteConfig.name.toLowerCase()}/latest/remoteEntry.js`);
+            : withRemotesPath(`${remoteConfig.name.toLowerCase()}/latest/remoteEntry.js`);
 
           await loadRemoteEntry(remote.title, remoteUrl);
           await __webpack_init_sharing__("default");

--- a/remotes/home/index.js
+++ b/remotes/home/index.js
@@ -25,7 +25,7 @@ const Home = () => {
       return acc;
     }, []);
   };
-
+  //testing version increase
   const meSectionComponent = <MeSection />;
   // Map articleImages to CustomCard components
   const cardComponents = articleImages.map((image, index) => (

--- a/remotes/home/index.js
+++ b/remotes/home/index.js
@@ -25,6 +25,7 @@ const Home = () => {
       return acc;
     }, []);
   };
+  //change
   const meSectionComponent = <MeSection />;
   // Map articleImages to CustomCard components
   const cardComponents = articleImages.map((image, index) => (

--- a/remotes/home/index.js
+++ b/remotes/home/index.js
@@ -25,7 +25,6 @@ const Home = () => {
       return acc;
     }, []);
   };
-  //change
   const meSectionComponent = <MeSection />;
   // Map articleImages to CustomCard components
   const cardComponents = articleImages.map((image, index) => (

--- a/remotes/home/index.js
+++ b/remotes/home/index.js
@@ -25,7 +25,6 @@ const Home = () => {
       return acc;
     }, []);
   };
-  //testing version increase
   const meSectionComponent = <MeSection />;
   // Map articleImages to CustomCard components
   const cardComponents = articleImages.map((image, index) => (

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -11,7 +11,7 @@ export const loader = async () => {
 
 const Resume = () => {
   const { resumeMarkdown } = useResumeStore();
-
+  //change
   return (
     <Box sx={{ padding: 4 }}>
       <ReactMarkdown

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -11,7 +11,6 @@ export const loader = async () => {
 
 const Resume = () => {
   const { resumeMarkdown } = useResumeStore();
-  //change
   return (
     <Box sx={{ padding: 4 }}>
       <ReactMarkdown

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -8,6 +8,7 @@ export const loader = async () => {
   return fetchResume();
 };
   //testing version increase
+  //change
 
 const Resume = () => {
   const { resumeMarkdown } = useResumeStore();

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -14,32 +14,46 @@ const Resume = () => {
 
   return (
     <Box sx={{ padding: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        Resume
-      </Typography>
       <ReactMarkdown
-        components={{
-          h1: ({ node, ...props }) => (
+  components={{
+    h1: ({ node, ...props }) => (
             <Typography variant="h4" gutterBottom {...props} />
           ),
-          h2: ({ node, ...props }) => (
-            <Typography variant="h5" gutterBottom {...props} />
-          ),
-          h3: ({ node, ...props }) => (
-            <Typography variant="h6" gutterBottom {...props} />
-          ),
-          p: ({ node, ...props }) => (
-            <Typography variant="body1" paragraph {...props} />
-          ),
-          li: ({ node, ...props }) => <ListItem {...props} />,
-          ul: ({ node, ...props }) => <List sx={{ pl: 4 }} {...props} />,
-          ol: ({ node, ...props }) => (
-            <List sx={{ pl: 4 }} component="ol" {...props} />
-          ),
+    h2: ({ node, ...props }) => (
+      <Typography variant="h5" gutterBottom {...props} />
+    ),
+    h3: ({ node, ...props }) => (
+      <Typography variant="h6" gutterBottom {...props} />
+    ),
+    p: ({ node, ...props }) => (
+      <Typography variant="body1" paragraph {...props} />
+    ),
+    ul: ({ node, ...props }) => (
+      <Box component="ul" sx={{ pl: 4, m: 0 }} {...props} />
+    ),
+    li: ({ node, ...props }) => (
+      <Typography
+        component="li"
+        variant="body1"
+        sx={{
+          listStyleType: "disc",
+          pl: 2,
+          mb: 1,
         }}
-      >
-        {resumeMarkdown}
-      </ReactMarkdown>
+        {...props}
+      />
+    ),
+    strong: ({ node, ...props }) => (
+      <Typography
+        component="span"
+        sx={{ fontWeight: "bold", display: "inline" }}
+        {...props}
+      />
+    ),
+  }}
+>
+  {resumeMarkdown}
+</ReactMarkdown>
     </Box>
   );
 };

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -7,6 +7,7 @@ export const loader = async () => {
   const { fetchResume } = useResumeStore.getState();
   return fetchResume();
 };
+  //testing version increase
 
 const Resume = () => {
   const { resumeMarkdown } = useResumeStore();

--- a/remotes/resume/index.js
+++ b/remotes/resume/index.js
@@ -7,8 +7,6 @@ export const loader = async () => {
   const { fetchResume } = useResumeStore.getState();
   return fetchResume();
 };
-  //testing version increase
-  //change
 
 const Resume = () => {
   const { resumeMarkdown } = useResumeStore();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -15,6 +15,7 @@ export const loader = async () => {
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
 };
+  //testing version increase
 
 const Writings = () => {
   const navigate = useNavigate();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -14,7 +14,6 @@ export const loader = async () => {
   //add in API calls here from store
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
-  //change
 };
 const Writings = () => {
   const navigate = useNavigate();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -15,7 +15,7 @@ export const loader = async () => {
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
 };
-
+  //change
 const Writings = () => {
   const navigate = useNavigate();
   const { articles } = useArticleStore();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -14,6 +14,7 @@ export const loader = async () => {
   //add in API calls here from store
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
+  //change
 };
 const Writings = () => {
   const navigate = useNavigate();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -15,7 +15,6 @@ export const loader = async () => {
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
 };
-  //testing version increase
 
 const Writings = () => {
   const navigate = useNavigate();

--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -15,7 +15,6 @@ export const loader = async () => {
   const { loadArticles } = useArticleStore.getState();
   return loadArticles();
 };
-  //change
 const Writings = () => {
   const navigate = useNavigate();
   const { articles } = useArticleStore();

--- a/scripts/buildAll.mjs
+++ b/scripts/buildAll.mjs
@@ -148,7 +148,9 @@ async function buildAll() {
     ? process.env.REMOTE_NAMES.split(/[,\s]+/).filter(Boolean)
     : null;
   if (only) {
-    remotes = remotes.filter(r => only.includes(r.name));
+    remotes = remotes.filter(r =>
+      only.includes(r.name) || only.includes(r.name.toLowerCase())
+    );
   }
   const hostDeps = require(path.resolve(process.cwd(), "package.json")).dependencies;
   const hostShared = generateShared(hostDeps);

--- a/scripts/buildAll.mjs
+++ b/scripts/buildAll.mjs
@@ -36,12 +36,12 @@ function mergeShared(hostShared) {
   return hostShared;
 }
 
-function createRemoteConfig(remote, hostShared) {
+function createRemoteConfig(remote, hostShared, version) {
   return {
     mode: "production",
     entry: path.resolve(process.cwd(), remote.entry),
     output: {
-      path: path.resolve(process.cwd(), "dist", remote.name),
+      path: path.resolve(process.cwd(), "dist", remote.name, version),
       filename: "bundle.js",
       publicPath: "auto",
       library: { type: "var", name: remote.name },
@@ -143,14 +143,26 @@ function runWebpack(config, label) {
 }
 
 async function buildAll() {
-  const remotes = await loadRemotes();
+  let remotes = await loadRemotes();
+  const only = process.env.REMOTE_NAMES
+    ? process.env.REMOTE_NAMES.split(/[,\s]+/).filter(Boolean)
+    : null;
+  if (only) {
+    remotes = remotes.filter(r => only.includes(r.name));
+  }
   const hostDeps = require(path.resolve(process.cwd(), "package.json")).dependencies;
   const hostShared = generateShared(hostDeps);
 
   const remotesMap = {};
   for (const r of remotes) {
-    await runWebpack(createRemoteConfig(r, hostShared), r.name);
-    remotesMap[r.name] = `${r.name}@${r.name}/remoteEntry.js`;
+    const pkg = require(path.resolve(process.cwd(), r.folder, 'package.json'));
+    const version = pkg.version;
+    await runWebpack(createRemoteConfig(r, hostShared, version), `${r.name} v${version}`);
+    const versionPath = path.resolve(process.cwd(), 'dist', r.name, version);
+    const latestPath = path.resolve(process.cwd(), 'dist', r.name, 'latest');
+    await fs.rm(latestPath, { recursive: true, force: true });
+    await fs.cp(versionPath, latestPath, { recursive: true });
+    remotesMap[r.name] = `${r.name}@/remotes/${r.name.toLowerCase()}/latest/remoteEntry.js`;
   }
 
   await runWebpack(createHostConfig(remotesMap, hostShared), "host");

--- a/scripts/buildHost.mjs
+++ b/scripts/buildHost.mjs
@@ -95,7 +95,7 @@ async function buildHost() {
   const remotes = await loadRemotes();
   const remotesMap = {};
   remotes.forEach((r) => {
-    remotesMap[r.name] = `${r.name}@/dist/${r.name}/remoteEntry.js`;
+    remotesMap[r.name] = `${r.name}@/remotes/${r.name.toLowerCase()}/latest/remoteEntry.js`;
   });
   const hostDeps = require("../package.json").dependencies;
   const shared = generateShared(hostDeps);

--- a/scripts/bumpRemoteVersions.mjs
+++ b/scripts/bumpRemoteVersions.mjs
@@ -1,0 +1,33 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+function incPatch(version) {
+  const parts = version.split('.').map(Number);
+  while (parts.length < 3) parts.push(0);
+  parts[2] = (parts[2] || 0) + 1;
+  return parts.join('.');
+}
+
+async function bump(remote) {
+  const pkgPath = path.resolve('remotes', remote, 'package.json');
+  const json = JSON.parse(await fs.readFile(pkgPath, 'utf-8'));
+  const oldVersion = json.version || '0.0.0';
+  const newVersion = incPatch(oldVersion);
+  json.version = newVersion;
+  await fs.writeFile(pkgPath, JSON.stringify(json, null, 2) + '\n');
+  console.log(`${remote} version bumped from ${oldVersion} to ${newVersion}`);
+}
+
+const names = process.env.REMOTE_NAMES
+  ? process.env.REMOTE_NAMES.split(/[\s,]+/).filter(Boolean)
+  : [];
+
+if (names.length === 0) {
+  console.log('No remotes provided for version bump');
+  process.exit(0);
+}
+
+Promise.all(names.map(bump)).catch(err => {
+  console.error('Failed to bump versions:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- change host to load remotes from `/latest`
- output remote builds into versioned folders and copy to `latest`
- build host with updated remote URLs
- detect changed remote folders dynamically in deploy workflow and only build/deploy those
- upload versioned builds and overwrite `latest` in Azure

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848aa2bc3c0832cbdcf201ca0ea3c1e