### PR TITLE
Fix remote paths in deploy workflow

### DIFF
--- a/.github/workflows/deploy-remotes.yml
+++ b/.github/workflows/deploy-remotes.yml
@@ -70,8 +70,9 @@ jobs:
             tmpfile=$(mktemp)
             for remote in $REMOTE_NAMES; do
               lower=$(echo "$remote" | tr '[:upper:]' '[:lower:]')
+              remote_cap=${remote^}
               version=$(grep -oP '"version":\s*"\K[^" ]+' "remotes/${lower}/package.json")
-              src="dist/${remote}/${version}"
+              src="dist/${remote_cap}/${version}"
               mkdir -p "$src"
               az storage blob upload --account-name uiremotes --container-name '$web' --file "$tmpfile" --name "remotes/${lower}/${version}/.init" --overwrite --auth-mode login
               az storage blob upload --account-name uiremotes --container-name '$web' --file "$tmpfile" --name "remotes/${lower}/latest/.init" --overwrite --auth-mode login


### PR DESCRIPTION
## Summary
- ensure deploy script uploads from `dist/<RemoteName>/<version>`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848be609448832c89b48c4be65a5eab