### PR TITLE
Add article creation modal

### DIFF
--- a/remotes/writings/index.js
+++ b/remotes/writings/index.js
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Grid2 as Grid,
   Card,
   CardContent,
   Typography,
   CardActionArea,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
 } from "@mui/material";
 import { useArticleStore } from "./store/useArticleStore";
 import { useNavigate } from "react-router-dom";
@@ -16,30 +22,92 @@ export const loader = async () => {
 };
 const Writings = () => {
   const navigate = useNavigate();
-  const { articles } = useArticleStore();
-  console.log(articles);
+  const { articles, createArticle } = useArticleStore();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ title: "", author: "", slug: "", content: "" });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async () => {
+    await createArticle(form);
+    setOpen(false);
+    setForm({ title: "", author: "", slug: "", content: "" });
+  };
+
+  const formIncomplete = Object.values(form).some((v) => v.trim() === "");
 
   return (
-    <Grid container spacing={2} padding={3}>
-      {articles.length > 0 ? (
-        articles.map((article) => (
-          <Grid key={article.slug}>
-            <Card>
-              <CardActionArea
-                onClick={() => navigate(`/writings/${article.slug}`)}
-              >
-                <CardContent>
-                  <Typography variant="h6">{article.title}</Typography>
-                  <Typography variant="body2">{article.summary}</Typography>
-                </CardContent>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        ))
-      ) : (
-        <ComingSoon />
-      )}
-    </Grid>
+    <>
+      <Button variant="contained" onClick={() => setOpen(true)} sx={{ mb: 2 }}>
+        Add writing
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>Add Writing</DialogTitle>
+        <DialogContent>
+          <TextField
+            margin="dense"
+            fullWidth
+            label="Title"
+            name="title"
+            value={form.title}
+            onChange={handleChange}
+          />
+          <TextField
+            margin="dense"
+            fullWidth
+            label="Author"
+            name="author"
+            value={form.author}
+            onChange={handleChange}
+          />
+          <TextField
+            margin="dense"
+            fullWidth
+            label="Slug"
+            name="slug"
+            value={form.slug}
+            onChange={handleChange}
+          />
+          <TextField
+            margin="dense"
+            fullWidth
+            multiline
+            label="Content"
+            name="content"
+            value={form.content}
+            onChange={handleChange}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+          <Button onClick={handleSubmit} disabled={formIncomplete}>
+            Submit
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Grid container spacing={2} padding={3}>
+        {articles.length > 0 ? (
+          articles.map((article) => (
+            <Grid key={article.slug}>
+              <Card>
+                <CardActionArea
+                  onClick={() => navigate(`/writings/${article.slug}`)}
+                >
+                  <CardContent>
+                    <Typography variant="h6">{article.title}</Typography>
+                    <Typography variant="body2">{article.summary}</Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          ))
+        ) : (
+          <ComingSoon />
+        )}
+      </Grid>
+    </>
   );
 };
 

--- a/remotes/writings/store/useArticleStore.js
+++ b/remotes/writings/store/useArticleStore.js
@@ -27,4 +27,22 @@ export const useArticleStore = create((set, get) => ({
   getArticleBySlug: (slug) => {
     return get().articles.find((article) => article.slug === slug);
   },
+
+  createArticle: async (article) => {
+    const { apiPath } = useEnvStore.getState();
+    if (!apiPath) return;
+    const res = await fetch(withApiPath('/articles'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(article),
+    });
+    if (!res.ok) return;
+    let saved;
+    try {
+      saved = await res.json();
+    } catch (e) {
+      saved = article;
+    }
+    set((state) => ({ articles: [...state.articles, saved] }));
+  },
 }));

--- a/remotes/writings/tests/useArticleStore.test.js
+++ b/remotes/writings/tests/useArticleStore.test.js
@@ -35,3 +35,33 @@ test('loadArticle loads current article', async () => {
   expect(article.slug).toBe('one');
   expect(article.articleText).toBe('text');
 });
+
+test('createArticle posts article', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          title: 'My First Article',
+          content: 'Hello world',
+          author: 'codex',
+          slug: 'test',
+        }),
+    })
+  );
+  const article = {
+    title: 'My First Article',
+    content: 'Hello world',
+    author: 'codex',
+    slug: 'test',
+  };
+  await act(async () => {
+    await useArticleStore.getState().createArticle(article);
+  });
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/articles'),
+    expect.objectContaining({ method: 'POST' })
+  );
+  const articles = useArticleStore.getState().articles;
+  expect(articles[articles.length - 1].slug).toBe('test');
+});


### PR DESCRIPTION
## Summary
- add modal to create a new writing
- add `createArticle` API call in article store
- test article creation

## Testing
- `npm install`
- `npm test` *(fails: Cannot read properties of undefined etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684bdc352f98832c9d81aa98cb18acfb