### PR TITLE
Add Jest tests for env and global stores

### DIFF
--- a/host/tests/App.test.js
+++ b/host/tests/App.test.js
@@ -14,7 +14,10 @@ beforeEach(() => {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ pages: [] }) });
     }
     if (url === '/remotes.json') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([{ name: 'home', port: 3001 }]) });
+    }
+    if (url.includes('remoteEntry.js')) {
+      return Promise.resolve({ ok: true, headers: { get: () => 'Wed, 21 Oct 2015 07:28:00 GMT' } });
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
   });
@@ -22,6 +25,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.resetAllMocks();
+  delete global.fetch;
 });
 
 test('renders loading initially then shows navbar', async () => {

--- a/host/tests/Footer.test.js
+++ b/host/tests/Footer.test.js
@@ -2,16 +2,16 @@ import { render, screen } from '@testing-library/react';
 import Footer from '../src/Footer';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
-const renderFooter = () => {
+const renderFooter = (props) => {
   const theme = createTheme();
   return render(
     <ThemeProvider theme={theme}>
-      <Footer />
+      <Footer {...props} />
     </ThemeProvider>
   );
 };
 
 test('displays latest release text', () => {
-  renderFooter();
+  renderFooter({ latestDate: new Date('2020-01-01') });
   expect(screen.getByText(/latest release/i)).toBeInTheDocument();
 });

--- a/host/tests/Navbar.test.js
+++ b/host/tests/Navbar.test.js
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import Navbar from '../src/Navbar';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useMsal } from '@azure/msal-react';
+import { useGlobalData } from '@anthonyv449/ui-kit';
 
 jest.mock('@azure/msal-react');
 
@@ -16,6 +17,11 @@ const renderNavbar = (props) => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  useGlobalData.setState({ user: null });
+});
+
+afterEach(() => {
+  delete global.fetch;
 });
 
 test('renders login button when no user', () => {
@@ -27,6 +33,7 @@ test('renders login button when no user', () => {
 test('calls login on button click', () => {
   const loginPopup = jest.fn().mockResolvedValue();
   useMsal.mockReturnValue({ instance: { loginPopup, logoutPopup: jest.fn() }, accounts: [] });
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
   renderNavbar({ pages: [] });
   fireEvent.click(screen.getByText(/sign in/i));
   expect(loginPopup).toHaveBeenCalled();
@@ -35,6 +42,7 @@ test('calls login on button click', () => {
 test('shows logout when user logged in', () => {
   const logoutPopup = jest.fn();
   useMsal.mockReturnValue({ instance: { loginPopup: jest.fn(), logoutPopup }, accounts: [{ name: 'Tester' }] });
+  useGlobalData.setState({ user: { name: 'Tester' } });
   renderNavbar({ pages: [] });
   expect(screen.getByText(/logout/i)).toBeInTheDocument();
 });

--- a/remotes/writings/tests/useArticleStore.test.js
+++ b/remotes/writings/tests/useArticleStore.test.js
@@ -1,5 +1,6 @@
 import { act } from 'react';
 import { useArticleStore } from '../store/useArticleStore';
+import { useEnvStore } from '../../../ui-kit/hooks/useEnv';
 
 beforeEach(() => {
   global.fetch = jest.fn((url) => {
@@ -11,12 +12,28 @@ beforeEach(() => {
         ]),
       });
     }
+    if (url.includes('/articles/') ) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ slug: 'one', articleText: 'text' }),
+      });
+    }
+    if (url.includes('/articles')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([
+          { slug: 'one', title: 't', summary: 's', file: '/file.md' },
+        ]),
+      });
+    }
     return Promise.resolve({ ok: true, text: () => Promise.resolve('text') });
   });
+  useEnvStore.setState({ apiPath: "https://api.test.com" });
 });
 
 afterEach(() => {
   jest.resetAllMocks();
+  useEnvStore.setState({ apiPath: null });
 });
 
 test('loadArticles stores articles', async () => {

--- a/ui-kit/tests/useEnv.test.js
+++ b/ui-kit/tests/useEnv.test.js
@@ -1,0 +1,49 @@
+import { useEnvStore, withHostPath, withRemotesPath, withApiPath, DEFAULT_DOMAIN, HOST_PATH } from '../hooks/useEnv';
+
+beforeEach(() => {
+  // reset store state before each test
+  useEnvStore.setState({
+    domain: DEFAULT_DOMAIN,
+    hostPath: HOST_PATH,
+    loaded: false,
+    apiPath: null,
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  delete global.fetch;
+});
+
+test('withHostPath builds url with domain and hostPath', () => {
+  useEnvStore.setState({ domain: 'https://cdn.test.com', hostPath: '/host' });
+  expect(withHostPath('/file.json')).toBe('https://cdn.test.com/host/file.json');
+});
+
+test('withRemotesPath builds url under remotes path', () => {
+  useEnvStore.setState({ domain: 'https://cdn.test.com' });
+  expect(withRemotesPath('home/remoteEntry.js')).toBe('https://cdn.test.com/remotes/home/remoteEntry.js');
+});
+
+test('withApiPath prefers apiPath when set', () => {
+  useEnvStore.setState({ domain: 'https://cdn.test.com', hostPath: '/host', apiPath: 'https://api.test.com' });
+  expect(withApiPath('/articles', '/articles/articles.json')).toBe('https://api.test.com/articles');
+});
+
+test('withApiPath falls back to host path when apiPath not set', () => {
+  useEnvStore.setState({ domain: 'https://cdn.test.com', hostPath: '/host', apiPath: null });
+  expect(withApiPath('/articles', '/articles/articles.json')).toBe('https://cdn.test.com/host/articles/articles.json');
+});
+
+test('loadEnv fetches env.json and updates store', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ domain: 'https://cdn.example.com', hostPath: '/h', apiPath: 'https://api.example.com' })
+  }));
+  await useEnvStore.getState().loadEnv();
+  const state = useEnvStore.getState();
+  expect(state.domain).toBe('https://cdn.example.com');
+  expect(state.hostPath).toBe('/h');
+  expect(state.apiPath).toBe('https://api.example.com');
+  expect(state.loaded).toBe(true);
+});

--- a/ui-kit/tests/useGlobalData.test.js
+++ b/ui-kit/tests/useGlobalData.test.js
@@ -1,0 +1,45 @@
+import { useGlobalData } from '../hooks/useGlobalData';
+import { useEnvStore } from '../hooks/useEnv';
+
+beforeEach(() => {
+  useGlobalData.setState({ user: null });
+  useEnvStore.setState({ apiPath: null });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  delete global.fetch;
+});
+
+test('loadUser does nothing when apiPath not set', async () => {
+  global.fetch = jest.fn();
+  await useGlobalData.getState().loadUser();
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(useGlobalData.getState().user).toBeNull();
+});
+
+test('loadUser fetches and sets user when apiPath is set', async () => {
+  useEnvStore.setState({ apiPath: 'https://api.test.com' });
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ name: 'tester' }) }));
+  await useGlobalData.getState().loadUser();
+  expect(global.fetch).toHaveBeenCalledWith('https://api.test.com/auth/me', { credentials: 'include' });
+  expect(useGlobalData.getState().user).toEqual({ name: 'tester' });
+});
+
+test('logoutUser posts to api and clears user', async () => {
+  useEnvStore.setState({ apiPath: 'https://api.test.com' });
+  useGlobalData.setState({ user: { name: 'tester' } });
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+  await useGlobalData.getState().logoutUser();
+  expect(global.fetch).toHaveBeenCalledWith('https://api.test.com/auth/logout', { method: 'POST', credentials: 'include' });
+  expect(useGlobalData.getState().user).toBeNull();
+});
+
+test('logoutUser does nothing if apiPath not set', async () => {
+  useEnvStore.setState({ apiPath: null });
+  useGlobalData.setState({ user: { name: 'tester' } });
+  global.fetch = jest.fn();
+  await useGlobalData.getState().logoutUser();
+  expect(global.fetch).not.toHaveBeenCalled();
+  expect(useGlobalData.getState().user).toEqual({ name: 'tester' });
+});


### PR DESCRIPTION
## Summary
- add new tests for env helpers and global data store
- adjust Navbar and Footer tests
- mock remote metadata in App tests
- update writings store tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f8aef8748832c89ee42eb4534de15