### PR TITLE
Add loader tests for remotes

### DIFF
--- a/remotes/home/tests/loader.test.js
+++ b/remotes/home/tests/loader.test.js
@@ -1,0 +1,11 @@
+import { loader } from '../index';
+import { useImageStore } from '../stores/useImageStore';
+
+test('loader calls loadArticleImages', async () => {
+  const original = useImageStore.getState().loadArticleImages;
+  const mock = jest.fn();
+  useImageStore.setState({ loadArticleImages: mock });
+  await loader();
+  expect(mock).toHaveBeenCalled();
+  useImageStore.setState({ loadArticleImages: original });
+});

--- a/remotes/resume/tests/loader.test.js
+++ b/remotes/resume/tests/loader.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { loader } from '../index';
+import { useResumeStore } from '../store/useResumeStore';
+
+jest.mock('react-markdown', () => () => <div />);
+
+test('loader calls fetchResume', async () => {
+  const original = useResumeStore.getState().fetchResume;
+  const mock = jest.fn();
+  useResumeStore.setState({ fetchResume: mock });
+  await loader();
+  expect(mock).toHaveBeenCalled();
+  useResumeStore.setState({ fetchResume: original });
+});

--- a/remotes/writings/tests/loader.test.js
+++ b/remotes/writings/tests/loader.test.js
@@ -1,0 +1,13 @@
+import { loader } from '../index';
+import { useArticleStore } from '../store/useArticleStore';
+
+jest.mock('react-router-dom', () => ({ useNavigate: () => jest.fn() }));
+
+test('loader calls loadArticles', async () => {
+  const original = useArticleStore.getState().loadArticles;
+  const mock = jest.fn();
+  useArticleStore.setState({ loadArticles: mock });
+  await loader();
+  expect(mock).toHaveBeenCalled();
+  useArticleStore.setState({ loadArticles: original });
+});


### PR DESCRIPTION
## Summary
- add unit tests for loaders in Home, Resume, and Writings remotes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f8db4e38c832cbbb77325040587d7