### PR TITLE
fix: share ui-kit as runtime singleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "ISC",
       "workspaces": [
         "remotes/*",
-        "host",
-        "ui-kit"
+        "host"
       ],
       "dependencies": {
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@azure/msal-browser": "^4.9.1",
         "@azure/msal-react": "^3.0.8",
         "@emotion/react": "^11.14.0",
@@ -12864,7 +12864,7 @@
       "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.6",
+        "@anthonyv449/ui-kit": "^1.3.12",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12877,7 +12877,7 @@
         "zustand": "^5.0.3"
       },
       "peerDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.11",
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12894,7 +12894,7 @@
       "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.6",
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12907,7 +12907,7 @@
         "zustand": "^5.0.3"
       },
       "peerDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.11",
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12927,7 +12927,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.6",
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12940,7 +12940,7 @@
         "zustand": "^5.0.3"
       },
       "peerDependencies": {
-        "@anthonyv449/ui-kit": "^1.3.11",
+        "@anthonyv449/ui-kit": "^1.3.15",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.1",
@@ -12955,7 +12955,7 @@
     },
     "ui-kit": {
       "name": "@anthonyv449/ui-kit",
-      "version": "1.3.11",
+      "version": "1.3.15",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.27.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@anthonyv449/ui-kit": "^1.3.15",
     "@azure/msal-browser": "^4.9.1",
     "@azure/msal-react": "^3.0.8",
     "@emotion/react": "^11.14.0",
@@ -52,7 +53,7 @@
     "zustand": "^5.0.3"
   },
   "mfShared": [
-    "@anthonyv449/ui-kit@^1.3.15",
+    "@anthonyv449/ui-kit",
     "@emotion/react",
     "@emotion/styled",
     "@mui/icons-material",

--- a/scripts/buildAllRemotes.mjs
+++ b/scripts/buildAllRemotes.mjs
@@ -32,9 +32,9 @@ function generateShared() {
 
     shared[pkg] = {
       singleton: true,
-      eager: true,
       requiredVersion: deps[pkg],
       strictVersion: true,
+      ...(pkg === "@anthonyv449/ui-kit" ? {} : { eager: true }),
     };
   });
 

--- a/scripts/buildHost.mjs
+++ b/scripts/buildHost.mjs
@@ -27,9 +27,9 @@ function generateShared() {
 
     shared[pkg] = {
       singleton: true,
-      eager: true,
       requiredVersion: deps[pkg],
       strictVersion: true,
+      ...(pkg === "@anthonyv449/ui-kit" ? {} : { eager: true }),
     };
   });
 

--- a/scripts/setupApp.mjs
+++ b/scripts/setupApp.mjs
@@ -32,9 +32,9 @@ function generateShared() {
 
     shared[pkg] = {
       singleton: true,
-      eager: true,
       requiredVersion: deps[pkg],
       strictVersion: true,
+      ...(pkg === "@anthonyv449/ui-kit" ? {} : { eager: true }),
     };
   });
 


### PR DESCRIPTION
## Summary
- add @anthonyv449/ui-kit to dependencies and mfShared list
- avoid eager loading of @anthonyv449/ui-kit in Module Federation shared config so remotes reuse host store

## Testing
- `npm test` *(fails: Cannot find module '@anthonyv449/ui-kit' and JSX transform errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0de88ec0832ca12da3d36624da7f